### PR TITLE
fix: rename primary mongoDB database from HP to hp

### DIFF
--- a/mongodb.js
+++ b/mongodb.js
@@ -10,7 +10,7 @@ async function dbConnect(url) {
 	console.log("Connecting to MongoDB...");
 	await client.connect();
 	console.log("Database connected");
-	const database = client.db('HP');
+	const database = client.db('hp');
 	return [client, database];
 }
 

--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ const cors = require('@fastify/cors');
 // TODO: Where should we store these constants?
 const port = 80;
 const host = "0.0.0.0";
-const mongoUrl = "mongodb://localhost:27017/HP"; // TODO: better place for this
+const mongoUrl = "mongodb://localhost:27017/hp"; // TODO: better place for this
 
 /**
  * Starts up the fastify server.


### PR DESCRIPTION
the database name "HP" appears to not work on our Debian EC2 instance, possibly due to MongoDB having corrupted data where the name HP is concerned. This simply changes the case of the name "HP" to "hp".