### PR TITLE
fix: post route definitions

### DIFF
--- a/mongodb.js
+++ b/mongodb.js
@@ -10,7 +10,7 @@ async function dbConnect(url) {
 	console.log("Connecting to MongoDB...");
 	await client.connect();
 	console.log("Database connected");
-	const database = client.db('HP');
+	const database = client.db('hp');
 	return [client, database];
 }
 

--- a/server.js
+++ b/server.js
@@ -19,6 +19,7 @@ async function start() {
 
   // Start the server
   setupGets();
+  await connectToDB();
   fastify.listen({ host: host, port: port }, (err, address) => {
     if (err) {
       console.error(err);
@@ -93,9 +94,7 @@ async function fastifyPostHelper(reply, database, func, args) {
 }
 
 function main() {
-  start().then(() =>
-    connectToDB()
-  );
+  start();
 }
 
 // This is needed so that server.test.js doesn't run main()

--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ const cors = require('@fastify/cors');
 // TODO: Where should we store these constants?
 const port = 80;
 const host = "0.0.0.0";
-const mongoUrl = "mongodb://localhost:27017/HP"; // TODO: better place for this
+const mongoUrl = "mongodb://localhost:27017/hp"; // TODO: better place for this
 
 /**
  * Starts up the fastify server.


### PR DESCRIPTION
In our server.js file, the POST routes need to be setup before we start listening on any ports. This moves the database setup step (which includes defining our POST routes) before we start listening.

Also, we cannot name our database "HP" on our Debian EC2 instance, possibly due to corruption. I've renamed the database from "HP" to "hp".