### PR TITLE
feat: `getSimulationReport` by id, `generateSimulationReport`, add default `WorkflowStep`s

### DIFF
--- a/mongodb.js
+++ b/mongodb.js
@@ -30,8 +30,13 @@ async function dbSetup(database) {
 
 	// Insert dummy data
 	const pj_id = await newPrintJob(database, "PrintJob 1", 5, ["RP 1"]);
-	const ws_id = await newWorkflowStep(database, "WorkflowStep 1", null, null, 10, 7);
-	const wf_id = await newWorkflow(database, "Workflow 1", [ws_id]);
+	const wk_id1 = await newWorkflowStep(database, "Preflight", null, null, 10, 7);
+	const wk_id2 = await newWorkflowStep(database, "Metrics", wk_id1, null, 2, 1);
+	const wk_id3 = await newWorkflowStep(database, "Rasterization", wk_id2, null, 50, 16);
+	const wk_id4 = await newWorkflowStep(database, "Printing", wk_id3, null, 10, 7);
+	const wk_id5 = await newWorkflowStep(database, "Cutting", wk_id4, null, 10, 7);
+	const wk_id6 = await newWorkflowStep(database, "Laminating", wk_id5, null, 10, 7);
+	const wf_id = await newWorkflow(database, "Workflow 1", [wk_id1, wk_id2, wk_id3, wk_id4, wk_id5, wk_id6]);
 	await newSimulationReport(database, pj_id, wf_id, 3, 4);
 }
 

--- a/server.js
+++ b/server.js
@@ -64,7 +64,7 @@ function setupGets(database) {
       reply.code(404).send("WorkflowDoc not found");
       return;
     }
-    const simulationReport = await database.collection('SimulationReport').findOne({PrintJobID: printJob._id, WorkflowID: workflowDoc._id});
+    const simulationReport = await database.collection('SimulationReport').findOne({PrintJobID: printJob._id, WorkflowID: workflow._id});
     if (!simulationReport) reply.code(404).send("Simulation report not found");
     else reply.code(200).send({PrintJob: printJob, SimulationReport: simulationReport});
   });
@@ -75,7 +75,7 @@ function setupGets(database) {
    */
   fastify.get('/generateSimulationReport', async (request, reply) => {
     const {jobID, workflowID} = request.query;
-    
+
     const printJob = await database.collection('PrintJob').findOne({_id: jobID});
     if (!printJob) {
       reply.code(404).send("PrintJob not found");

--- a/server.js
+++ b/server.js
@@ -71,6 +71,8 @@ function setupGets(database) {
   });
 
 
+   // SIMULATION REPORTS 
+
    /**
    * Get an existing simulation report from a 
    * PrintJob id and Workflow id
@@ -115,14 +117,29 @@ function setupGets(database) {
     reply.code(200).send(simulationReport);
   });
 
+  fastify.get('/getSimulationReportList', async (request, reply) => {
+    const simulationReports = await database.collection('SimulationReport').find();
+    if (!simulationReports) {
+      reply.code(404).send("No SimulationReports found");
+      return;
+    }
+    const reportList = [];
+    for await (const report of simulationReports) {
+      reportList.push(report);
+    }
+    reply.code(200).send(reportList);
+  });
+
+
+  // WORKFLOWS AND STEPS
   fastify.get('/getWorkflowList', async (request, reply) => {
-    const workflowDocs = await database.collection('Workflow').find();
-    if (!workflowDocs) {
+    const workflows = await database.collection('Workflow').find();
+    if (!workflows) {
       reply.code(404).send("WorkflowDocs not found");
       return;
     }
     const workflowList = [];
-    for await (const doc of workflowDocs) {
+    for await (const doc of workflows) {
       workflowList.push({WorkflowID: doc._id, Title: doc.Title});
     }
     reply.code(200).send(workflowList);

--- a/simulation.js
+++ b/simulation.js
@@ -1,0 +1,11 @@
+/**
+ * Simulate a PrintJob through the given Workflow
+ * @param {*} printJob 
+ * @param {*} workflow 
+ * @returns {*} the SimulationReport as a JSON 
+ */
+async function simulate(printJob, workflow){
+    return 
+}
+
+module.exports = { simulate };

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -86,6 +86,10 @@ test('GET /getWorkflowList', async (t) => {
     console.log("Workflows: ", payloadList);
 });
 
+/*
+
+TODO: replace title and workflow with IDs
+
 test('GET /getSimulationReport', async (t) => {
     // parameters
     const title = 'PrintJob 1';
@@ -98,6 +102,7 @@ test('GET /getSimulationReport', async (t) => {
     const payload = JSON.parse(response.payload);
     console.log("Simulation Report:", payload);
 });
+*/
 
 test('GET /getWorkflowStepList', async (t) => {
     const response = await fastify.inject({
@@ -109,3 +114,5 @@ test('GET /getWorkflowStepList', async (t) => {
     if (!payloadList) console.log("WorkflowStepList is null");
     else console.log("Workflow steps: ", payloadList);
 });
+
+// TODO: create generateSimulationReport test

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -93,7 +93,8 @@ test('GET /getWorkflowList', async (t) => {
     });
     assert.strictEqual(response.statusCode, 200);
     const payloadList = response.payload;
-    console.log("Workflows: ", payloadList);
+    if (!payloadList) console.error("payload is null");
+    else console.log("All workflows: ", payloadList);
 });
 
 /*
@@ -115,6 +116,18 @@ test('GET /getSimulationReport', async (t) => {
 
 // TODO: create generateSimulationReport test
 
+test('GET /getSimulationReportList', async (t) => {
+    const response = await fastify.inject({
+        method: 'GET',
+        url: '/getSimulationReportList'
+    });
+    assert.strictEqual(response.statusCode, 200);
+    const payloadList = response.payload;
+    if (!payloadList) console.error("payload is null");
+    else console.log("All simulation reports: ", payloadList);
+});
+
+
 test('GET /getWorkflowStepList', async (t) => {
     const response = await fastify.inject({
         method: 'GET',
@@ -122,6 +135,6 @@ test('GET /getWorkflowStepList', async (t) => {
     });
     assert.strictEqual(response.statusCode, 200);
     const payloadList = response.payload;
-    if (!payloadList) console.log("WorkflowStepList is null");
-    else console.log("Workflow steps: ", payloadList);
+    if (!payloadList) console.error("payload is null");
+    else console.log("All workflow steps: ", payloadList);
 });


### PR DESCRIPTION
* Modified `getSimulationReport` to take PrintJob ID and Workflow ID instead of title
* Created `generateSimulationReport` that takes in PrintJob ID and Workflow ID and then calls `simulate` in `simulation.js`. Returns the newly generated simulation report as JSON.
* Created `getSimulationReportList` that returns all simulation reports.
* Added default workflow steps to "Workflow 1" during Mongo setup