### PR TITLE
refactor: `server.test.js`, `server.js`, and `mongodb.js`

### DIFF
--- a/mongodb.js
+++ b/mongodb.js
@@ -69,7 +69,7 @@ async function insert(database, collection_name, doc) {
  */
 async function newPrintJob(database, title, page_count, rasterization_profile) {
 	// TODO: Check the validity of foreign keys
-	if (!db || !title || !page_count || !rasterization_profile || rasterization_profile.length == 0) {
+	if (!database || !title || !page_count || !rasterization_profile || rasterization_profile.length == 0) {
 		throw new Error("Invalid parameters for newPrintJob");
 	}
 	return await insert(database, "PrintJob", {
@@ -88,7 +88,7 @@ async function newPrintJob(database, title, page_count, rasterization_profile) {
  * @returns {*} The ID of the inserted workflow or an Error if it failed
  */
 async function newWorkflow(database, title, workflow_steps) {
-	if (!db || !title || !workflow_steps || workflow_steps.length == 0) {
+	if (!database || !title || !workflow_steps || workflow_steps.length == 0) {
 		throw new Error("Invalid parameters for newWorkflow");
 	}
 	return await insert(database, "Workflow", {
@@ -109,7 +109,7 @@ async function newWorkflow(database, title, workflow_steps) {
  */
 async function newWorkflowStep(database, title, previous_step=null, next_step=null, setup_time=0, time_per_page=1) {
 	// previous_step and next_step are ok to be null
-	if (!db || !title || !setup_time || !time_per_page) {
+	if (!database || !title || !setup_time || !time_per_page) {
 		throw new Error("Invalid parameters for newWorkflowStep");
 	}
 	return await insert(database, "WorkflowStep", {
@@ -131,7 +131,7 @@ async function newWorkflowStep(database, title, previous_step=null, next_step=nu
  * @returns {*} The ID of the inserted report or an Error if it failed
  */
 async function newSimulationReport(database, print_job_id, workflow_id, total_time_taken, rasterization_time_taken) {
-	if (!db || !print_job_id || !workflow_id || !total_time_taken || !rasterization_time_taken) {
+	if (!database || !print_job_id || !workflow_id || !total_time_taken || !rasterization_time_taken) {
 		throw new Error("Invalid parameters for newSimulationReport");
 	}
 	return await insert(database, "SimulationReport", {

--- a/mongodb.js
+++ b/mongodb.js
@@ -1,4 +1,5 @@
 // Db, Int32, and ObjectId are needed for IDE support to know what the types are
+// eslint-disable-next-line no-unused-vars
 const { Db, Int32, ObjectId, MongoClient, Timestamp } = require("mongodb"); 
 
 /**
@@ -71,7 +72,7 @@ async function newPrintJob(database, title, page_count, rasterization_profile) {
 	if (!database || !title || !page_count || !rasterization_profile || rasterization_profile.length == 0) {
 		throw new Error("Invalid parameters for newPrintJob");
 	}
-	return await insert(database, "PrintJob", {
+	return insert(database, "PrintJob", {
 		Title: title,
 		DateCreated: new Timestamp(),
 		PageCount: page_count,
@@ -90,7 +91,7 @@ async function newWorkflow(database, title, workflow_steps) {
 	if (!database || !title || !workflow_steps || workflow_steps.length == 0) {
 		throw new Error("Invalid parameters for newWorkflow");
 	}
-	return await insert(database, "Workflow", {
+	return insert(database, "Workflow", {
 		Title: title,
 		WorkflowSteps: workflow_steps
 	});
@@ -111,15 +112,13 @@ async function newWorkflowStep(database, title, previous_step=null, next_step=nu
 	if (!database || !title || !setup_time || !time_per_page) {
 		throw new Error("Invalid parameters for newWorkflowStep");
 	}
-	const result = await insert(database, "WorkflowStep", {
+	return insert(database, "WorkflowStep", {
 		Title: title,
 		PreviousStep: previous_step,
 		NextStep: next_step,
 		SetupTime: setup_time,
 		TimePerPage: time_per_page
 	});
-	console.log("newWorkflowStep returning: ", result);	
-	return result;
 }
 
 /**
@@ -135,7 +134,7 @@ async function newSimulationReport(database, print_job_id, workflow_id, total_ti
 	if (!database || !print_job_id || !workflow_id || !total_time_taken || !rasterization_time_taken) {
 		throw new Error("Invalid parameters for newSimulationReport");
 	}
-	return await insert(database, "SimulationReport", {
+	return insert(database, "SimulationReport", {
 		PrintJobID: print_job_id,
 		WorkflowID: workflow_id,
 		TotalTimeTaken: total_time_taken,

--- a/mongodb.js
+++ b/mongodb.js
@@ -88,10 +88,14 @@ async function newPrintJob(database, title, page_count, rasterization_profile) {
  * @returns {ObjectId} The ID of the inserted workflow or an Error if it failed
  */
 async function newWorkflow(database, title, workflow_steps) {
+	// Validate parameters
 	if (!database || !title || !workflow_steps || workflow_steps.length == 0) {
 		throw new Error("Invalid parameters for newWorkflow");
 	}
-	console.log("HERE: ", workflow_steps);
+	if (!Array.isArray(workflow_steps) || !workflow_steps.every(id => ObjectId.isValid(id))) {
+		throw new Error("newWorkflow: workflow_steps must be an array of valid ObjectIds");
+	}
+
 	return await insert(database, "Workflow", {
 		Title: title,
 		WorkflowSteps: workflow_steps

--- a/mongodb.js
+++ b/mongodb.js
@@ -91,6 +91,7 @@ async function newWorkflow(database, title, workflow_steps) {
 	if (!database || !title || !workflow_steps || workflow_steps.length == 0) {
 		throw new Error("Invalid parameters for newWorkflow");
 	}
+	console.log("HERE: ", workflow_steps);
 	return await insert(database, "Workflow", {
 		Title: title,
 		WorkflowSteps: workflow_steps

--- a/mongodb.js
+++ b/mongodb.js
@@ -1,6 +1,5 @@
-// v Not needed? v
-// const { Db, Int32, ObjectId, MongoClient, Timestamp } = require("mongodb");
-const { MongoClient, Timestamp } = require("mongodb");
+// Db, Int32, and ObjectId are needed for IDE support to know what the types are
+const { Db, Int32, ObjectId, MongoClient, Timestamp } = require("mongodb"); 
 
 /**
  * Connects to the MongoDB database and returns the client and database objects.
@@ -45,9 +44,9 @@ async function dbSetup(database) {
 /**
  * Inserts a document (i.e. instance/row) into the given collection (i.e. table).
  * @param {Db} database The Mongo database object
- * @param {*} collection_name The collection name
+ * @param {string} collection_name The collection name
  * @param {*} doc The document to insert into the database
- * @returns {*} The ID of the inserted document or an Error if it failed
+ * @returns {ObjectId} The ID of the inserted document or an Error if it failed
  */
 async function insert(database, collection_name, doc) {
 	const collection = database.collection(collection_name);
@@ -65,7 +64,7 @@ async function insert(database, collection_name, doc) {
  * @param {string} title 
  * @param {Int32} page_count 
  * @param {string[]} rasterization_profile 
- * @returns {*} The ID of the inserted print job or an Error if it failed
+ * @returns {ObjectId} The ID of the inserted print job or an Error if it failed
  */
 async function newPrintJob(database, title, page_count, rasterization_profile) {
 	// TODO: Check the validity of foreign keys
@@ -85,7 +84,7 @@ async function newPrintJob(database, title, page_count, rasterization_profile) {
  * @param {Db} database 
  * @param {string} title 
  * @param {ObjectId[]} workflow_steps 
- * @returns {*} The ID of the inserted workflow or an Error if it failed
+ * @returns {ObjectId} The ID of the inserted workflow or an Error if it failed
  */
 async function newWorkflow(database, title, workflow_steps) {
 	if (!database || !title || !workflow_steps || workflow_steps.length == 0) {
@@ -105,7 +104,7 @@ async function newWorkflow(database, title, workflow_steps) {
  * @param {ObjectId} next_step 
  * @param {Int32} setup_time 
  * @param {Int32} time_per_page 
- * @returns {*} The ID of the inserted step or an Error if it failed
+ * @returns {ObjectId} The ID of the inserted step or an Error if it failed
  */
 async function newWorkflowStep(database, title, previous_step=null, next_step=null, setup_time=0, time_per_page=1) {
 	// previous_step and next_step are ok to be null
@@ -130,7 +129,7 @@ async function newWorkflowStep(database, title, previous_step=null, next_step=nu
  * @param {ObjectId} workflow_id 
  * @param {Int32} total_time_taken 
  * @param {Int32} rasterization_time_taken 
- * @returns {*} The ID of the inserted report or an Error if it failed
+ * @returns {ObjectId} The ID of the inserted report or an Error if it failed
  */
 async function newSimulationReport(database, print_job_id, workflow_id, total_time_taken, rasterization_time_taken) {
 	if (!database || !print_job_id || !workflow_id || !total_time_taken || !rasterization_time_taken) {

--- a/mongodb.js
+++ b/mongodb.js
@@ -43,31 +43,19 @@ async function dbSetup(database) {
 }
 
 /**
- * 
- * @param {Db} database 
- * @param {*} collection_name 
- * @param {*} doc 
- * @returns 
+ * Inserts a document (i.e. instance/row) into the given collection (i.e. table).
+ * @param {Db} database The Mongo database object
+ * @param {*} collection_name The collection name
+ * @param {*} doc The document to insert into the database
+ * @returns {*} The ID of the inserted document or an Error if it failed
  */
 async function insert(database, collection_name, doc) {
 	const collection = database.collection(collection_name);
 	const insert = await collection.insertOne(doc);
 	if (insert.acknowledged) {
-		// TODO: Do Stuff
+		return insert.insertedId;
 	} else {
-		// TODO: Do other stuff
-	}
-	return insert.insertedId;
-}
-
-/**
- * Checks if the given array contains any null values.
- * @param {*[]} args 
- */
-function checkNull(args) {
-	for (const arg of args) {
-		// TODO: are we sure about throwing an error here?
-		if (arg === null) throw new Error("Invalid argument");
+		throw new Error("Insert into " + collection_name + " failed");
 	}
 }
 
@@ -77,12 +65,10 @@ function checkNull(args) {
  * @param {string} title 
  * @param {Int32} page_count 
  * @param {string[]} rasterization_profile 
- * @returns 
+ * @returns {*} The ID of the inserted print job or an Error if it failed
  */
 async function newPrintJob(database, title, page_count, rasterization_profile) {
 	// TODO: Check the validity of foreign keys
-	// TODO: Is there a way to place type constraints on a function?
-	checkNull([database, title, page_count, rasterization_profile]);
 	return await insert(database, "PrintJob", {
 		Title: title,
 		DateCreated: new Timestamp(),
@@ -96,7 +82,7 @@ async function newPrintJob(database, title, page_count, rasterization_profile) {
  * @param {Db} database 
  * @param {string} title 
  * @param {ObjectId[]} workflow_steps 
- * @returns 
+ * @returns {*} The ID of the inserted workflow or an Error if it failed
  */
 async function newWorkflow(database, title, workflow_steps) {
 	checkNull([database, title, workflow_steps]);
@@ -114,7 +100,7 @@ async function newWorkflow(database, title, workflow_steps) {
  * @param {ObjectId} next_step 
  * @param {Int32} setup_time 
  * @param {Int32} time_per_page 
- * @returns 
+ * @returns {*} The ID of the inserted step or an Error if it failed
  */
 async function newWorkflowStep(database, title, previous_step, next_step, setup_time, time_per_page) {
 	checkNull([database, title, setup_time, time_per_page]);
@@ -134,7 +120,7 @@ async function newWorkflowStep(database, title, previous_step, next_step, setup_
  * @param {ObjectId} workflow_id 
  * @param {Int32} total_time_taken 
  * @param {Int32} rasterization_time_taken 
- * @returns 
+ * @returns {*} The ID of the inserted report or an Error if it failed
  */
 async function newSimulationReport(database, print_job_id, workflow_id, total_time_taken, rasterization_time_taken) {
 	checkNull([database, print_job_id, workflow_id, total_time_taken, rasterization_time_taken]);
@@ -145,7 +131,6 @@ async function newSimulationReport(database, print_job_id, workflow_id, total_ti
 		RasterizationTimeTaken: rasterization_time_taken,
 		CreationTime: Date.now()
 	});
-	// make sure that the return value of the query is not empty
 }
 
 module.exports = {

--- a/mongodb.js
+++ b/mongodb.js
@@ -72,7 +72,7 @@ async function newPrintJob(database, title, page_count, rasterization_profile) {
 	if (!database || !title || !page_count || !rasterization_profile || rasterization_profile.length == 0) {
 		throw new Error("Invalid parameters for newPrintJob");
 	}
-	return insert(database, "PrintJob", {
+	return await insert(database, "PrintJob", {
 		Title: title,
 		DateCreated: new Timestamp(),
 		PageCount: page_count,
@@ -91,7 +91,7 @@ async function newWorkflow(database, title, workflow_steps) {
 	if (!database || !title || !workflow_steps || workflow_steps.length == 0) {
 		throw new Error("Invalid parameters for newWorkflow");
 	}
-	return insert(database, "Workflow", {
+	return await insert(database, "Workflow", {
 		Title: title,
 		WorkflowSteps: workflow_steps
 	});
@@ -112,7 +112,7 @@ async function newWorkflowStep(database, title, previous_step=null, next_step=nu
 	if (!database || !title || !setup_time || !time_per_page) {
 		throw new Error("Invalid parameters for newWorkflowStep");
 	}
-	return insert(database, "WorkflowStep", {
+	return await insert(database, "WorkflowStep", {
 		Title: title,
 		PreviousStep: previous_step,
 		NextStep: next_step,
@@ -134,7 +134,7 @@ async function newSimulationReport(database, print_job_id, workflow_id, total_ti
 	if (!database || !print_job_id || !workflow_id || !total_time_taken || !rasterization_time_taken) {
 		throw new Error("Invalid parameters for newSimulationReport");
 	}
-	return insert(database, "SimulationReport", {
+	return await insert(database, "SimulationReport", {
 		PrintJobID: print_job_id,
 		WorkflowID: workflow_id,
 		TotalTimeTaken: total_time_taken,

--- a/mongodb.js
+++ b/mongodb.js
@@ -112,13 +112,15 @@ async function newWorkflowStep(database, title, previous_step=null, next_step=nu
 	if (!database || !title || !setup_time || !time_per_page) {
 		throw new Error("Invalid parameters for newWorkflowStep");
 	}
-	return await insert(database, "WorkflowStep", {
+	const result = await insert(database, "WorkflowStep", {
 		Title: title,
 		PreviousStep: previous_step,
 		NextStep: next_step,
 		SetupTime: setup_time,
 		TimePerPage: time_per_page
 	});
+	console.log("newWorkflowStep returning: ", result);	
+	return result;
 }
 
 /**

--- a/mongodb.js
+++ b/mongodb.js
@@ -69,6 +69,9 @@ async function insert(database, collection_name, doc) {
  */
 async function newPrintJob(database, title, page_count, rasterization_profile) {
 	// TODO: Check the validity of foreign keys
+	if (!db || !title || !page_count || !rasterization_profile || rasterization_profile.length == 0) {
+		throw new Error("Invalid parameters for newPrintJob");
+	}
 	return await insert(database, "PrintJob", {
 		Title: title,
 		DateCreated: new Timestamp(),
@@ -85,7 +88,9 @@ async function newPrintJob(database, title, page_count, rasterization_profile) {
  * @returns {*} The ID of the inserted workflow or an Error if it failed
  */
 async function newWorkflow(database, title, workflow_steps) {
-	checkNull([database, title, workflow_steps]);
+	if (!db || !title || !workflow_steps || workflow_steps.length == 0) {
+		throw new Error("Invalid parameters for newWorkflow");
+	}
 	return await insert(database, "Workflow", {
 		Title: title,
 		WorkflowSteps: workflow_steps
@@ -102,8 +107,11 @@ async function newWorkflow(database, title, workflow_steps) {
  * @param {Int32} time_per_page 
  * @returns {*} The ID of the inserted step or an Error if it failed
  */
-async function newWorkflowStep(database, title, previous_step, next_step, setup_time, time_per_page) {
-	checkNull([database, title, setup_time, time_per_page]);
+async function newWorkflowStep(database, title, previous_step=null, next_step=null, setup_time=0, time_per_page=1) {
+	// previous_step and next_step are ok to be null
+	if (!db || !title || !setup_time || !time_per_page) {
+		throw new Error("Invalid parameters for newWorkflowStep");
+	}
 	return await insert(database, "WorkflowStep", {
 		Title: title,
 		PreviousStep: previous_step,
@@ -123,7 +131,9 @@ async function newWorkflowStep(database, title, previous_step, next_step, setup_
  * @returns {*} The ID of the inserted report or an Error if it failed
  */
 async function newSimulationReport(database, print_job_id, workflow_id, total_time_taken, rasterization_time_taken) {
-	checkNull([database, print_job_id, workflow_id, total_time_taken, rasterization_time_taken]);
+	if (!db || !print_job_id || !workflow_id || !total_time_taken || !rasterization_time_taken) {
+		throw new Error("Invalid parameters for newSimulationReport");
+	}
 	return await insert(database, "SimulationReport", {
 		PrintJobID: print_job_id,
 		WorkflowID: workflow_id,
@@ -134,10 +144,10 @@ async function newSimulationReport(database, print_job_id, workflow_id, total_ti
 }
 
 module.exports = {
-    dbConnect,
-    dbSetup,
-    newPrintJob,
-    newWorkflow,
-    newWorkflowStep,
-    newSimulationReport
+	dbConnect,
+	dbSetup,
+	newPrintJob,
+	newWorkflow,
+	newWorkflowStep,
+	newSimulationReport
 };

--- a/mongodb.js
+++ b/mongodb.js
@@ -135,8 +135,8 @@ async function newWorkflowStep(database, title, previous_step=null, next_step=nu
  * @param {Int32} rasterization_time_taken 
  * @returns {ObjectId} The ID of the inserted report or an Error if it failed
  */
-async function newSimulationReport(database, print_job_id, workflow_id, total_time_taken, rasterization_time_taken) {
-	if (!database || !print_job_id || !workflow_id || !total_time_taken || !rasterization_time_taken) {
+async function newSimulationReport(database, print_job_id, workflow_id, total_time_taken=0, rasterization_time_taken=0) {
+	if (!database || !print_job_id || !workflow_id) {
 		throw new Error("Invalid parameters for newSimulationReport");
 	}
 	return await insert(database, "SimulationReport", {

--- a/server.js
+++ b/server.js
@@ -238,6 +238,7 @@ function setupPosts(database) {
   fastify.post('/createWorkflow', async (request, reply) => {
     try {
       // Map each WorkflowStep to a ObjectID
+      console.log(request.body.WorkflowSteps[0]);
       const workflowSteps = request.body.WorkflowSteps.map(stepID => new ObjectId(stepID));
       // Create a new workflow
       const result = await newWorkflow(database, request.body.Title, workflowSteps);

--- a/server.js
+++ b/server.js
@@ -238,21 +238,10 @@ function setupPosts(database) {
   fastify.post('/createWorkflow', async (request, reply) => {
 
     // Map each WorkflowStep to a ObjectID
-    console.log("HERE: ", request.body.WorkflowSteps);
-    let workflowSteps = [];
-    try {
-      workflowSteps = request.body.WorkflowSteps.map(stepID => new ObjectId(stepID));
-    }
-    catch (err) {
-      reply.code(500).send("Could not map step IDs to ObjectIDs: ", err.message);
-      return;
-    }
-    if (workflowSteps.length == 0) {
-      reply.code(500).send("No valid WorkflowSteps provided");
-      return;
-    }
+    const workflowSteps = await request.body.WorkflowSteps.map(stepID => new ObjectId(stepID));
+
     // Create a new workflow
-    console.log("HERE: ", workflowSteps);
+    console.log("AFTER MAPPING: ", workflowSteps);
     const result = await newWorkflow(database, request.body.Title, workflowSteps);
     reply.code(200).send(result);
 

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ const mongoUrl = "mongodb://db.wsuv-hp-capstone.com:27017/hp";
  * Starts up the fastify server and connects to the Mongo database.
  * @param {string} host The host address
  * @param {number} port The port number
+ * @param {string} url The Mongo database URL
  */
 async function start(host = "0.0.0.0", port = 80, url = mongoUrl) {
   try {
@@ -51,29 +52,36 @@ function setupGets(database) {
     reply.code(200).send('Hello, client!');
   });
 
-
+  /**
+   * Preform a query on a given collection
+   */
   fastify.get('/query', async (request, reply) => {
-    let message = "";
-    let code = 200;
-    const Query = JSON.parse(request.query.Query);
-    const Collection = database.collection(request.query.CollectionName);
-    try { message = await Collection.find(Query).toArray(); }
-    catch (err) { message = err; code = 500; }
-    reply.code(code).send(message);
+    try {
+      const Query = JSON.parse(request.query.Query);
+      const Collection = database.collection(request.query.CollectionName);
+      const result = await Collection.find(Query).toArray();
+      reply.code(200).send(result);
+    }
+    catch (err) {
+      reply.code(500).send(err.message);
+    }
   });
 
 
+  /**
+   * Get an existing print job from a title
+   */
   fastify.get('/getPrintJob', async (request, reply) => {
-    let message = "";
-    let code = 200;
-    const Collection = database.collection("PrintJob");
-    try { message = await Collection.find({ "Title": request.query.Title }).toArray(); }
-    catch (err) { message = err; code = 500; }
-    reply.code(code).send(message);
+    try {
+      const Collection = database.collection("PrintJob");
+      const result = await Collection.find({ "Title": request.query.Title }).toArray();
+      reply.code(200).send(result);
+    }
+    catch (err) {
+      reply.code(404).send(err.message);
+    }
   });
 
-
-  // SIMULATION REPORTS 
 
   /**
   * Get an existing simulation report from a 
@@ -92,16 +100,21 @@ function setupGets(database) {
       return;
     }
     const simulationReport = await database.collection('SimulationReport').findOne({ PrintJobID: new ObjectId(printJob._id), WorkflowID: new ObjectId(workflow._id) });
-    if (!simulationReport) reply.code(404).send("Simulation report not found");
-    else reply.code(200).send({ PrintJob: printJob, SimulationReport: simulationReport });
+    if (!simulationReport) {
+      reply.code(404).send("Simulation report not found");
+    }
+    else {
+      reply.code(200).send({ PrintJob: printJob, SimulationReport: simulationReport });
+    }
   });
+
 
   /**
    * Generate a simulation report (see simulation.js)
    * for a given PrintJob id and Workflow id
    */
   fastify.get('/generateSimulationReport', async (request, reply) => {
-    //TODO: Should this really be a get?
+    //TODO: Change to a POST
     const { jobID, workflowID } = request.query;
 
     const printJob = await database.collection('PrintJob').findOne({ _id: new ObjectId(jobID) });
@@ -116,69 +129,85 @@ function setupGets(database) {
       return;
     }
 
-    let code = 200;
-    const simulationReportId = await simulate(printJob, workflow, database);
     try {
-      var message = await database.collection('SimulationReport').findOne(
+      const simulationReportId = await simulate(printJob, workflow, database);
+      const result = await database.collection('SimulationReport').findOne(
         { _id: simulationReportId });
+      reply.code(200).send(result);
     }
-    catch (err) { message = err; code = 500; }
-    reply.code(code).send(message);
+    catch (err) {
+      reply.code(500).send(err.message);
+    }
   });
 
+
+  /**
+   * Get a list of all simulation reports
+   */
   fastify.get('/getSimulationReportList', async (request, reply) => {
-    const simulationReports = await database.collection('SimulationReport').find();
-    if (!simulationReports) {
-      reply.code(404).send("No SimulationReports found");
-      return;
-    }
-
-    const reportList = [];
-    for await (const report of simulationReports) {
-      report.PrintJobTitle = '';
-      report.WorkflowTitle = '';
-
-      const titles = await Promise.all([
-        database.collection('PrintJob').findOne({ _id: new ObjectId(report.PrintJobID) }),
-        database.collection('Workflow').findOne({ _id: new ObjectId(report.WorkflowID) }),
-      ]);
-
-      const printJob = titles[0];
-      if (printJob) {
-        report.PrintJobTitle = printJob.Title;
+    try {
+      const simulationReports = await database.collection('SimulationReport').find();
+      if (!simulationReports) {
+        reply.code(404).send("No SimulationReports found");
+        return;
       }
 
-      const workflow = titles[1];
-      if (workflow) {
-        report.WorkflowTitle = workflow.Title;
-      }
+      const reportList = [];
+      for await (const report of simulationReports) {
+        report.PrintJobTitle = '';
+        report.WorkflowTitle = '';
 
-      reportList.push(report);
+        const titles = await Promise.all([
+          database.collection('PrintJob').findOne({ _id: new ObjectId(report.PrintJobID) }),
+          database.collection('Workflow').findOne({ _id: new ObjectId(report.WorkflowID) }),
+        ]);
+
+        const printJob = titles[0];
+        if (printJob) {
+          report.PrintJobTitle = printJob.Title;
+        }
+
+        const workflow = titles[1];
+        if (workflow) {
+          report.WorkflowTitle = workflow.Title;
+        }
+
+        reportList.push(report);
+      }
+      reply.code(200).send(reportList);
     }
-    reply.code(200).send(reportList);
+    catch (err) {
+      reply.code(500).send(err.message);
+    }
   });
 
 
-  // WORKFLOWS AND STEPS
+  /**
+   * Get a list of all workflows
+   */
   fastify.get('/getWorkflowList', async (request, reply) => {
     const workflows = await database.collection('Workflow').find();
     if (!workflows) {
-      reply.code(404).send("WorkflowDocs not found");
+      reply.code(404).send("No workflows found");
       return;
     }
     const workflowList = [];
-    for await (const doc of workflows) {
-      workflowList.push({ WorkflowID: doc._id, Title: doc.Title });
+    for await (const w of workflows) {
+      workflowList.push({ WorkflowID: w._id, Title: w.Title });
     }
     reply.code(200).send(workflowList);
   });
 
+
+  /**
+   * Get a list of all workflow steps
+   */
   fastify.get('/getWorkflowStepList', async (request, reply) => {
     try {
       const steps = await database.collection('WorkflowStep').find({}).toArray();
       reply.code(200).send(steps);
     } catch (err) {
-      reply.code(500).send({ error: err.message });
+      reply.code(500).send(err.message);
     }
   });
 }
@@ -189,48 +218,56 @@ function setupGets(database) {
  * @param {Db} database 
  */
 function setupPosts(database) {
+  // Create a new print job
   fastify.post('/createJob', async (request, reply) => {
     try {
       const result = newPrintJob(database, request.body.Title, request.body.PageCount, request.body.RasterizationProfile);
       reply.code(200).send(result);
     }
     catch (err) {
-      reply.code(err.code).send(err.message);
+      reply.code(500).send(err.message);
     }
   });
 
 
+  /**
+   * Create a new workflow
+   */
   fastify.post('/createWorkflow', async (request, reply) => {
-    // Map each WorkflowStep to a ObjectID
-    const workflowSteps = request.body.WorkflowSteps.map(step => new ObjectId(step));
-
-    await fastifyPostHelper(reply, database, newWorkflow,
-      [request.body.Title, workflowSteps]);
+    try {
+      // Map each WorkflowStep to a ObjectID
+      const workflowSteps = request.body.WorkflowSteps.map(stepID => new ObjectId(stepID));
+      // Create a new workflow
+      const result = newWorkflow(database, request.body.Title, workflowSteps);
+      reply.code(200).send(result);
+    }
+    catch (err) {
+      reply.code(500).send(err.message);
+    }
   });
 
 
+  /**
+   * Create a new workflow step
+   */
   fastify.post('/createWorkflowStep', async (request, reply) => {
-    await fastifyPostHelper(reply, database, newWorkflowStep,
-      [request.body.Title, request.body.PreviousStep, request.body.NextStep, request.body.SetupTime, request.body.TimePerPage]);
+    try {
+      // Create a new workflow step
+      const result = newWorkflowStep(database, request.body.Title, request.body.PreviousStep, request.body.NextStep, request.body.SetupTime, request.body.TimePerPage);
+      reply.code(200).send(result);
+    }
+    catch (err) {
+      reply.code(500).send(err.message);
+    }
   });
 }
-
-
-async function fastifyPostHelper(reply, database, func, args) {
-  let message = "Operation successful\n";
-  let code = 200;
-  try { await func(database, ...args); }
-  catch (err) { message = err; code = 500; }
-  finally { reply.code(code).send(message); }
-}
-
 
 // This allows passing in an alternate port as a command line argument
 if (require.main === module) {
-  if (process.argv.length > 3 && process.argv[3] == "-l")
+  if (process.argv.length > 3 && process.argv[3] == "-l") {
     start("0.0.0.0", process.argv[2], "mongodb://localhost:27017/hp");
+  }
   else start();
 }
-
 
 module.exports = { fastify, start };

--- a/server.js
+++ b/server.js
@@ -238,8 +238,9 @@ function setupPosts(database) {
   fastify.post('/createWorkflow', async (request, reply) => {
     try {
       // Map each WorkflowStep to a ObjectID
-      console.log(request.body.WorkflowSteps[0]);
+   
       const workflowSteps = request.body.WorkflowSteps.map(stepID => new ObjectId(stepID));
+      console.log(workflowSteps[0]);
       // Create a new workflow
       const result = await newWorkflow(database, request.body.Title, workflowSteps);
       reply.code(200).send(result);

--- a/server.js
+++ b/server.js
@@ -236,27 +236,26 @@ function setupPosts(database) {
    * Create a new workflow
    */
   fastify.post('/createWorkflow', async (request, reply) => {
+
+    // Map each WorkflowStep to a ObjectID
+    console.log("HERE: ", request.body.WorkflowSteps);
+    let workflowSteps = [];
     try {
-      // Map each WorkflowStep to a ObjectID
-      let workflowSteps = [];
-      try {
-        workflowSteps = request.body.WorkflowSteps.map(stepID => new ObjectId(stepID));
-      }
-      catch (err) {
-        reply.code(500).send("Could not map step IDs to ObjectIDs: ", err.message);
-        return;
-      }
-      if (workflowSteps.length == 0) {
-        reply.code(500).send("No valid WorkflowSteps provided");
-        return;
-      }
-      // Create a new workflow
-      const result = await newWorkflow(database, request.body.Title, workflowSteps);
-      reply.code(200).send(result);
+      workflowSteps = request.body.WorkflowSteps.map(stepID => new ObjectId(stepID));
     }
     catch (err) {
-      reply.code(500).send(err.message);
+      reply.code(500).send("Could not map step IDs to ObjectIDs: ", err.message);
+      return;
     }
+    if (workflowSteps.length == 0) {
+      reply.code(500).send("No valid WorkflowSteps provided");
+      return;
+    }
+    // Create a new workflow
+    console.log("HERE: ", workflowSteps);
+    const result = await newWorkflow(database, request.body.Title, workflowSteps);
+    reply.code(200).send(result);
+
   });
 
 

--- a/server.js
+++ b/server.js
@@ -190,8 +190,13 @@ function setupGets(database) {
  */
 function setupPosts(database) {
   fastify.post('/createJob', async (request, reply) => {
-    await fastifyPostHelper(reply, database, newPrintJob,
-      [request.body.Title, request.body.PageCount, request.body.RasterizationProfile]);
+    try {
+      const result = newPrintJob(database, request.body.Title, request.body.PageCount, request.body.RasterizationProfile);
+      reply.code(200).send(result);
+    }
+    catch (err) {
+      reply.code(err.code).send(err.message);
+    }
   });
 
 

--- a/server.js
+++ b/server.js
@@ -223,7 +223,7 @@ function setupPosts(database) {
    */
   fastify.post('/createJob', async (request, reply) => {
     try {
-      const result = newPrintJob(database, request.body.Title, request.body.PageCount, request.body.RasterizationProfile);
+      const result = await newPrintJob(database, request.body.Title, request.body.PageCount, request.body.RasterizationProfile);
       reply.code(200).send(result);
     }
     catch (err) {
@@ -240,7 +240,7 @@ function setupPosts(database) {
       // Map each WorkflowStep to a ObjectID
       const workflowSteps = request.body.WorkflowSteps.map(stepID => new ObjectId(stepID));
       // Create a new workflow
-      const result = newWorkflow(database, request.body.Title, workflowSteps);
+      const result = await newWorkflow(database, request.body.Title, workflowSteps);
       reply.code(200).send(result);
     }
     catch (err) {
@@ -254,8 +254,7 @@ function setupPosts(database) {
    */
   fastify.post('/createWorkflowStep', async (request, reply) => {
     try {
-      const result = newWorkflowStep(database, request.body.Title, request.body.PreviousStep, request.body.NextStep, request.body.SetupTime, request.body.TimePerPage);
-      console.log("HERE returning ", result);
+      const result = await newWorkflowStep(database, request.body.Title, request.body.PreviousStep, request.body.NextStep, request.body.SetupTime, request.body.TimePerPage);
       reply.code(200).send(result);
     }
     catch (err) {

--- a/server.js
+++ b/server.js
@@ -116,7 +116,8 @@ function setupGets(database) {
   fastify.get('/generateSimulationReport', async (request, reply) => {
     //TODO: Change to a POST
     const { jobID, workflowID } = request.query;
-
+    console.log("jobID: ", jobID);
+    console.log("workflowID: ", workflowID);
     const printJob = await database.collection('PrintJob').findOne({ _id: new ObjectId(jobID) });
     if (!printJob) {
       reply.code(404).send("PrintJob not found");

--- a/server.js
+++ b/server.js
@@ -238,15 +238,18 @@ function setupPosts(database) {
   fastify.post('/createWorkflow', async (request, reply) => {
     try {
       // Map each WorkflowStep to a ObjectID
-      const workflowSteps = request.body.WorkflowSteps.map(stepID => {
-        try {
-          return new ObjectId(stepID);
-        }
-        catch (err) {
-          reply.code(500).send("Could not map " + stepID + " to ObjectID: ", err.message);
-          return null;
-        }
-      });
+      let workflowSteps = [];
+      try {
+        workflowSteps = request.body.WorkflowSteps.map(stepID => new ObjectId(stepID));
+      }
+      catch (err) {
+        reply.code(500).send("Could not map step IDs to ObjectIDs: ", err.message);
+        return;
+      }
+      if (workflowSteps.length == 0) {
+        reply.code(500).send("No valid WorkflowSteps provided");
+        return;
+      }
       // Create a new workflow
       const result = await newWorkflow(database, request.body.Title, workflowSteps);
       reply.code(200).send(result);

--- a/server.js
+++ b/server.js
@@ -238,9 +238,15 @@ function setupPosts(database) {
   fastify.post('/createWorkflow', async (request, reply) => {
     try {
       // Map each WorkflowStep to a ObjectID
-   
-      const workflowSteps = request.body.WorkflowSteps.map(stepID => new ObjectId(stepID));
-      console.log(workflowSteps[0]);
+      const workflowSteps = request.body.WorkflowSteps.map(stepID => {
+        try {
+          return new ObjectId(stepID);
+        }
+        catch (err) {
+          reply.code(500).send("Could not map " + stepID + " to ObjectID: ", err.message);
+          return null;
+        }
+      });
       // Create a new workflow
       const result = await newWorkflow(database, request.body.Title, workflowSteps);
       reply.code(200).send(result);

--- a/server.js
+++ b/server.js
@@ -254,8 +254,8 @@ function setupPosts(database) {
    */
   fastify.post('/createWorkflowStep', async (request, reply) => {
     try {
-      // Create a new workflow step
       const result = newWorkflowStep(database, request.body.Title, request.body.PreviousStep, request.body.NextStep, request.body.SetupTime, request.body.TimePerPage);
+      console.log("HERE returning ", result);
       reply.code(200).send(result);
     }
     catch (err) {

--- a/server.js
+++ b/server.js
@@ -236,15 +236,16 @@ function setupPosts(database) {
    * Create a new workflow
    */
   fastify.post('/createWorkflow', async (request, reply) => {
+    try {
+      // Map each WorkflowStep to a ObjectID
+      const workflowSteps = await request.body.WorkflowSteps.map(stepID => new ObjectId(stepID));
 
-    // Map each WorkflowStep to a ObjectID
-    const workflowSteps = await request.body.WorkflowSteps.map(stepID => new ObjectId(stepID));
-
-    // Create a new workflow
-    console.log("AFTER MAPPING: ", workflowSteps);
-    const result = await newWorkflow(database, request.body.Title, workflowSteps);
-    reply.code(200).send(result);
-
+      // Create a new workflow
+      const result = await newWorkflow(database, request.body.Title, workflowSteps);
+      reply.code(200).send(result);
+    } catch (err) {
+      reply.code(500).send(err.message);
+    }
   });
 
 

--- a/server.js
+++ b/server.js
@@ -218,7 +218,9 @@ function setupGets(database) {
  * @param {Db} database 
  */
 function setupPosts(database) {
-  // Create a new print job
+  /**
+   * Create a new print job
+   */
   fastify.post('/createJob', async (request, reply) => {
     try {
       const result = newPrintJob(database, request.body.Title, request.body.PageCount, request.body.RasterizationProfile);

--- a/simulation.js
+++ b/simulation.js
@@ -77,7 +77,7 @@ async function isVisited(visited, check, mutex) {
  * 
  * @param {*} printJob 
  * @param {*} workflowSteps 
- * @param {string} step 
+ * @param {string} step The name of the workflow step
  * @returns 
  */
 async function simulateStep(printJob, workflowSteps, step) {
@@ -91,12 +91,11 @@ async function simulateStep(printJob, workflowSteps, step) {
 		"Cutting": placeholder,
 		"Laminating": placeholder,
 	}
-	try {
+	// Testing steps do not exist in funcs, so they will just
+	// use the simple calculation
+	if (workflowSteps[step] && typeof funcs[workflowSteps[step].func] === 'function') {
 		return await funcs[workflowSteps[step].func](workflowSteps[step], printJob);
-	}
-	catch {
-		// Testing steps do not exist in the funcs table
-		// so this is their substitute
+	} else {
 		return workflowSteps[step].time * printJob.PageCount;
 	}
 }

--- a/simulation.js
+++ b/simulation.js
@@ -81,8 +81,32 @@ async function isVisited(visited, check, mutex) {
  * @returns 
  */
 async function simulateStep(printJob, workflowSteps, step) {
-	if (!workflowSteps[step]) throw new Error("Step not found");
-	return workflowSteps[step].time * printJob.PageCount;
+	if(!workflowSteps[step]){
+		throw new Error("Step not found");
+	}
+
+	// TODO: in the future, steps will have different functions
+	// to simulate how long they take
+	const funcs = {
+		"Preflight": placeholder,
+		"Metrics": placeholder,
+		"Rasterization": placeholder,
+		"Printing": placeholder,
+		"Cutting": placeholder,
+		"Laminating": placeholder,
+	}
+	// Testing steps do not exist in funcs, so they will just
+	// use the simple calculation
+	if (typeof funcs[workflowSteps[step].func] === 'function') {
+		return await funcs[workflowSteps[step].func](workflowSteps[step], printJob);
+	} else {
+		return workflowSteps[step].time * printJob.PageCount;
+	}
+}
+
+
+async function placeholder(workflowStep, printJob) {
+	return workflowStep.time * printJob.PageCount;
 }
 
 

--- a/simulation.js
+++ b/simulation.js
@@ -40,8 +40,8 @@ async function simulate(printJob, workflow, database) {
 
 	// Find times for report
 	// TODO: This could be done in a single loop
-	let rastTime;
-	const totalTime = await Math.max(...Object.keys(results).map((k) => {
+	let rastTime = 0;
+	const totalTime = Math.max(...Object.keys(results).map((k) => {
 		if (results[k].stepName === "Rasterization") rastTime = results[k].stepTime;
 		return results[k].cumulative;
 	}));
@@ -75,7 +75,8 @@ async function isVisited(visited, check, mutex) {
 
 
 async function simulateStep(printJob, workflowSteps, step) {
-	// await new Promise(resolve => setTimeout(resolve, Math.random()*1000)); //TODO: Remove
+	// TODO: in the future, steps will have different functions
+	// to simulate how long they take
 	const funcs = {
 		"Preflight": placeholder,
 		"Metrics": placeholder,

--- a/simulation.js
+++ b/simulation.js
@@ -73,7 +73,13 @@ async function isVisited(visited, check, mutex) {
 	});
 }
 
-
+/**
+ * 
+ * @param {*} printJob 
+ * @param {*} workflowSteps 
+ * @param {string} step 
+ * @returns 
+ */
 async function simulateStep(printJob, workflowSteps, step) {
 	// TODO: in the future, steps will have different functions
 	// to simulate how long they take
@@ -85,7 +91,14 @@ async function simulateStep(printJob, workflowSteps, step) {
 		"Cutting": placeholder,
 		"Laminating": placeholder,
 	}
-	return await funcs[workflowSteps[step].func](workflowSteps[step], printJob)
+	try {
+		return await funcs[workflowSteps[step].func](workflowSteps[step], printJob);
+	}
+	catch {
+		// Testing steps do not exist in the funcs table
+		// so this is their substitute
+		return workflowSteps[step].time * printJob.PageCount;
+	}
 }
 
 

--- a/simulation.js
+++ b/simulation.js
@@ -82,7 +82,7 @@ async function isVisited(visited, check, mutex) {
  */
 async function simulateStep(printJob, workflowSteps, step) {
 	if(!workflowSteps[step]){
-		throw new Error("Step not found");
+		throw new Error("simulateStep: Step not found");
 	}
 
 	// TODO: in the future, steps will have different functions
@@ -95,6 +95,7 @@ async function simulateStep(printJob, workflowSteps, step) {
 		"Cutting": placeholder,
 		"Laminating": placeholder,
 	}
+
 	// Testing steps do not exist in funcs, so they will just
 	// use the simple calculation
 	if (typeof funcs[workflowSteps[step].func] === 'function') {

--- a/simulation.js
+++ b/simulation.js
@@ -81,28 +81,8 @@ async function isVisited(visited, check, mutex) {
  * @returns 
  */
 async function simulateStep(printJob, workflowSteps, step) {
-	// TODO: in the future, steps will have different functions
-	// to simulate how long they take
-	const funcs = {
-		"Preflight": placeholder,
-		"Metrics": placeholder,
-		"Rasterization": placeholder,
-		"Printing": placeholder,
-		"Cutting": placeholder,
-		"Laminating": placeholder,
-	}
-	// Testing steps do not exist in funcs, so they will just
-	// use the simple calculation
-	if (workflowSteps[step] && typeof funcs[workflowSteps[step].func] === 'function') {
-		return await funcs[workflowSteps[step].func](workflowSteps[step], printJob);
-	} else {
-		return workflowSteps[step].time * printJob.PageCount;
-	}
-}
-
-
-async function placeholder(workflowStep, printJob) {
-	return workflowStep.time * printJob.PageCount;
+	if (!workflowSteps[step]) throw new Error("Step not found");
+	return workflowSteps[step].time * printJob.PageCount;
 }
 
 

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -48,7 +48,7 @@ test('Full simulation report flow', async (ctx) => {
         assert.strictEqual(response.statusCode, 200);
         assert.ok(response.payload);
         const stepID = response.payload.toString().replace(/"/g, '');
-        console.log("ctx.stepID: ", stepID);
+        //console.log("ctx.stepID: ", stepID);
         ctx.stepID = stepID;
     });
 
@@ -58,7 +58,6 @@ test('Full simulation report flow', async (ctx) => {
             Title: "Test Workflow",
             WorkflowSteps: [ ctx.stepID ]
         }
-        console.log("HERE: ", JSON.stringify(data));
         const response = await fastify.inject({
             method: 'POST',
             url: '/createWorkflow',
@@ -77,10 +76,14 @@ test('Full simulation report flow', async (ctx) => {
         });
         assert.strictEqual(response.statusCode, 200);
         const payload = JSON.parse(response.payload);
+        console.log("payload: ", payload);  
         assert.ok(payload)
 
         ctx.workflowID = payload.WorkflowID;
         ctx.jobID = payload.PrintJobID; 
+
+        console.log("ctx.workflowID: ", ctx.workflowID);
+        console.log("ctx.jobID: ", ctx.jobID);
     });
 
     // 5. Generate the simulation report from the print job and workflow

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -81,7 +81,7 @@ test('Full simulation report flow', async (ctx) => {
             url: `/getPrintJob?Title=${encodeURIComponent(ctx.jobTitle)}`,
         });
         assert.strictEqual(response.statusCode, 200);
-        const payload = JSON.parse(response.payload[0]);
+        const payload = JSON.parse(response.payload)[0];
         console.log("getPrintJob payload: ", payload);
         assert.ok(payload)
         assert.equal(payload.Title, ctx.jobTitle);
@@ -106,12 +106,12 @@ test('Full simulation report flow', async (ctx) => {
             console.log("Error: ", response.payload);
         }
         assert.strictEqual(response.statusCode, 200);
-        const simulationReport = await JSON.parse(response.payload[0]);
-        console.log("Simulation Report: ", simulationReport);
+        const simulationReport = await JSON.parse(response.payload);
+        console.log("Generated simulation report: ", simulationReport);
         assert.ok(simulationReport);
         assert.strictEqual(simulationReport.PrintJobID, ctx.jobID);
         assert.strictEqual(simulationReport.WorkflowID, ctx.workflowID);
-        console.log("Generated simulation report: ", simulationReport);
+    
     });
 
     // 6. Make sure that the simulation report can be retrieved

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -59,7 +59,7 @@ test('Full simulation report flow', async (ctx) => {
     });
 
     // Get the print job and workflow id
-    test('GET /getPrintJob', async (t) => {
+    await test('GET /getPrintJob', async (t) => {
         const title = encodeURIComponent(jobTitle);
         const response = await fastify.inject({
             method: 'GET',
@@ -74,7 +74,7 @@ test('Full simulation report flow', async (ctx) => {
     });
 
     // Generate the simulation report
-    test('GET /generateSimulationReport', async (t) => {
+    await test('GET /generateSimulationReport', async (t) => {
         response = await fastify.inject({
             method: 'GET',
             url: '/generateSimulationReport',
@@ -94,7 +94,7 @@ test('Full simulation report flow', async (ctx) => {
         console.log("Generated simulation report: ", simulationReport);
     });
 
-    test('GET /getSimulationReport', async (t) => {
+    await test('GET /getSimulationReport', async (t) => {
         // Make sure that the simulation report 
         // can be retrieved
         response = await fastify.inject({

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -46,10 +46,9 @@ test('Full simulation report flow', async (ctx) => {
             }
         });
         assert.strictEqual(response.statusCode, 200);
-        const payload = JSON.parse(response.payload);
-        assert.ok(payload);
         // TODO: testing this
-        console.log("HERE: ", payload);
+        console.log("HERE: ", response.payload);
+        ctx.stepID = response.payload;
     });
 
     // 3. Create a new workflow with the above step

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -70,7 +70,7 @@ test('Full simulation report flow', async (ctx) => {
         assert.strictEqual(response.statusCode, 200);
         const payload = JSON.parse(response.payload);
         assert.ok(payload)
-        console.log(payload);
+        console.log("LOOK HERE: \n" + payload);
 
         ctx.workflowID = payload.WorkflowID;
         ctx.jobID = payload.PrintJobID; 

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -47,8 +47,8 @@ test('Full simulation report flow', async (ctx) => {
         });
         assert.strictEqual(response.statusCode, 200);
         assert.ok(response.payload);
-        console.log("Response: ", response.payload);
-        const stepID = response.payload.toString();
+        const stepID = response.payload.toString().replace(/"/g, '');
+        console.log("ctx.stepID: ", stepID);
         ctx.stepID = stepID;
     });
 

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -54,13 +54,15 @@ test('Full simulation report flow', async (ctx) => {
 
     // 3. Create a new workflow with the above step
     await test('POST /createWorkflow', async () => {
+        const data = {
+            Title: "Test Workflow",
+            WorkflowSteps: [ ctx.stepID ]
+        }
         const response = await fastify.inject({
             method: 'POST',
             url: '/createWorkflow',
-            body: {
-                Title: 'Test Workflow',
-                WorkflowSteps: [ctx.stepID]
-            }
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(data)
         });
         assert.strictEqual(response.statusCode, 200);
         assert.ok(response.payload);

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -120,6 +120,7 @@ describe('Full simulation report flow', async () => {
     });
 })
 
+
 // GET API CALLS
 test('GET /', async () => {
     const response = await fastify.inject({
@@ -138,7 +139,7 @@ test('GET /query', async () => {
         url: `/query?CollectionName=${CollectionName}&Query=${Query}`
     });
     assert.strictEqual(response.statusCode, 200);
-    console.log("Query Results: ", JSON.parse(response.payload));
+    //console.log("Query Results: ", JSON.parse(response.payload));
 });
 
 test('GET /getWorkflowStepList', async () => {
@@ -150,7 +151,7 @@ test('GET /getWorkflowStepList', async () => {
     const payloadList = response.payload;
     assert.ok(payloadList);
     assert.notEqual(payloadList.length, 0);
-    console.log("All workflow steps: ", payloadList);
+    //console.log("All workflow steps: ", payloadList);
 });
 
 test('GET /getSimulationReportList', async () => {
@@ -162,5 +163,5 @@ test('GET /getSimulationReportList', async () => {
     const payloadList = JSON.parse(response.payload);
     assert.ok(payloadList);
     assert.notEqual(payloadList.length, 0);
-    console.log("All simulation reports: ", payloadList);
+    //console.log("All simulation reports: ", payloadList);
 });

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -18,7 +18,7 @@ test('Full simulation report flow', async (ctx) => {
     ctx.workflowID = "";
 
     // Create a test print job and workflow
-    await test('POST /createJob', async (t) => {
+    await test('POST /createJob', async () => {
         const response = await fastify.inject({
             method: 'POST',
             url: '/createJob',
@@ -31,7 +31,7 @@ test('Full simulation report flow', async (ctx) => {
         assert.strictEqual(response.statusCode, 200);
     });
     
-    await test('POST /createWorkflowStep', async (t) => {
+    await test('POST /createWorkflowStep', async () => {
         const response = await fastify.inject({
             method: 'POST',
             url: '/createWorkflowStep',
@@ -46,7 +46,7 @@ test('Full simulation report flow', async (ctx) => {
         assert.strictEqual(response.statusCode, 200);
     });
 
-    await test('POST /createWorkflow', async (t) => {
+    await test('POST /createWorkflow', async () => {
         const response = await fastify.inject({
             method: 'POST',
             url: '/createWorkflow',
@@ -59,7 +59,7 @@ test('Full simulation report flow', async (ctx) => {
     });
 
     // Get the print job and workflow id
-    await test('GET /getPrintJob', async (t) => {
+    await test('GET /getPrintJob', async () => {
         const title = encodeURIComponent(jobTitle);
         const response = await fastify.inject({
             method: 'GET',
@@ -68,13 +68,14 @@ test('Full simulation report flow', async (ctx) => {
         assert.strictEqual(response.statusCode, 200);
         const payload = JSON.parse(response.payload);
         assert.ok(payload)
+        console.error(payload);
 
         ctx.workflowID = payload.WorkflowID;
         ctx.jobID = payload.PrintJobID; 
     });
 
     // Generate the simulation report
-    await test('GET /generateSimulationReport', async (t) => {
+    await test('GET /generateSimulationReport', async () => {
         response = await fastify.inject({
             method: 'GET',
             url: '/generateSimulationReport',
@@ -94,7 +95,7 @@ test('Full simulation report flow', async (ctx) => {
         console.log("Generated simulation report: ", simulationReport);
     });
 
-    await test('GET /getSimulationReport', async (t) => {
+    await test('GET /getSimulationReport', async () => {
         // Make sure that the simulation report 
         // can be retrieved
         response = await fastify.inject({
@@ -109,7 +110,7 @@ test('Full simulation report flow', async (ctx) => {
 })
 
 // GET API CALLS
-test('GET /', async (t) => {
+test('GET /', async () => {
     const response = await fastify.inject({
         method: 'GET',
         url: '/'
@@ -118,7 +119,7 @@ test('GET /', async (t) => {
     assert.strictEqual(response.payload, 'Hello, client!');
 });
 
-test('GET /query', async (t) => {
+test('GET /query', async () => {
     const CollectionName = encodeURIComponent('PrintJob');
     const Query = encodeURIComponent(JSON.stringify({ Title: "PrintJob 1" }))
     const response = await fastify.inject({
@@ -129,7 +130,7 @@ test('GET /query', async (t) => {
     console.log("Query Results: ", JSON.parse(response.payload));
 });
 
-test('GET /getWorkflowStepList', async (t) => {
+test('GET /getWorkflowStepList', async () => {
     const response = await fastify.inject({
         method: 'GET',
         url: '/getWorkflowStepList'
@@ -141,7 +142,7 @@ test('GET /getWorkflowStepList', async (t) => {
     console.log("All workflow steps: ", payloadList);
 });
 
-test('GET /getSimulationReportList', async (t) => {
+test('GET /getSimulationReportList', async () => {
     const response = await fastify.inject({
         method: 'GET',
         url: '/getSimulationReportList'

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -39,8 +39,8 @@ test('Full simulation report flow', async (ctx) => {
             url: '/createWorkflowStep',
             body: {
                 Title: 'Test Step 1',
-                PreviousStep: '',
-                NextStep: '',
+                PreviousStep: null,
+                NextStep: null,
                 SetupTime: 5,
                 TimePerPage: 2
             }

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -1,4 +1,4 @@
-const { test, before, after } = require('node:test');
+const { test, before, after, describe } = require('node:test');
 const assert = require('node:assert');
 const { fastify, start, } = require('../../server.js');
 
@@ -11,14 +11,14 @@ after(() => {
 }
 );
 
-test('Full simulation report flow', async (ctx) => {
-    ctx.jobTitle = "Test Job";
-    ctx.jobID = "";
-    ctx.stepID = "";
-    ctx.workflowID = "";
+const ctx = {};
 
-    // 1. Create a new print job
-    await test('POST /createJob', async () => {
+describe('Print Job and Workflow Tests', () => {
+    before(async (ctx) => {
+        ctx.jobTitle = 'Test Job';
+    });
+
+    test('Create a new print job', async () => {
         const response = await fastify.inject({
             method: 'POST',
             url: '/createJob',
@@ -31,9 +31,8 @@ test('Full simulation report flow', async (ctx) => {
         assert.strictEqual(response.statusCode, 200);
         assert.ok(response.payload);
     });
-    
-    // 2. Create a new workflow step
-    await test('POST /createWorkflowStep', async () => {
+
+    test('Create a new workflow step', async () => {
         const response = await fastify.inject({
             method: 'POST',
             url: '/createWorkflowStep',
@@ -51,8 +50,7 @@ test('Full simulation report flow', async (ctx) => {
         ctx.stepID = stepID;
     });
 
-    // 3. Create a new workflow with the above step
-    await test('POST /createWorkflow', async () => {
+    test('Create a new workflow with the above step', async () => {
         const data = {
             Title: "Test Workflow",
             WorkflowSteps: [ ctx.stepID ]
@@ -67,8 +65,7 @@ test('Full simulation report flow', async (ctx) => {
         assert.ok(response.payload);
     });
 
-    // 4. Get the print job and workflow id
-    await test('GET /getPrintJob', async () => {
+    test('Get the print job and workflow id', async () => {
         const response = await fastify.inject({
             method: 'GET',
             url: `/getPrintJob?Title=${encodeURIComponent(ctx.jobTitle)}`,
@@ -81,9 +78,8 @@ test('Full simulation report flow', async (ctx) => {
         ctx.jobID = payload.PrintJobID; 
     });
 
-    // 5. Generate the simulation report from the print job and workflow
-    await test('GET /generateSimulationReport', async () => {
-        response = await fastify.inject({
+    test('Generate the simulation report from the print job and workflow', async () => {
+        const response = await fastify.inject({
             method: 'GET',
             url: '/generateSimulationReport',
             query: {
@@ -102,11 +98,8 @@ test('Full simulation report flow', async (ctx) => {
         console.log("Generated simulation report: ", simulationReport);
     });
 
-    // 6. Make sure that the simulation report can be retrieved
-    await test('GET /getSimulationReport', async () => {
-        // Make sure that the simulation report 
-        // can be retrieved
-        response = await fastify.inject({
+    test('Make sure that the simulation report can be retrieved', async () => {
+        const response = await fastify.inject({
             method: 'GET',
             url: `/getSimulationReport?jobID=${encodeURIComponent(ctx.jobID)}&workflowID=${encodeURIComponent(ctx.workflowID)}`
         });
@@ -114,7 +107,7 @@ test('Full simulation report flow', async (ctx) => {
         const payload = JSON.parse(response.payload);
         assert.ok(payload);
     });
-})
+});
 
 // GET API CALLS
 test('GET /', async () => {

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -47,7 +47,7 @@ test('Full simulation report flow', async (ctx) => {
         });
         assert.strictEqual(response.statusCode, 200);
         assert.ok(response.payload);
-        assert.equal(typeof(response.payload), 'ObjectID', "Expected an ObjectID");
+        console.log("Response: ", response.payload);
         const stepID = response.payload.toString();
         ctx.stepID = stepID;
     });

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -11,6 +11,104 @@ after(() => {
 }
 );
 
+// SEQUENCED TEST
+test('Full simulation report flow', async (ctx) => {
+    const jobTitle = "Test Job";
+    ctx.jobID = "";
+    ctx.workflowID = "";
+
+    // Create a test print job and workflow
+    await test('POST /createJob', async (t) => {
+        const response = await fastify.inject({
+            method: 'POST',
+            url: '/createJob',
+            body: {
+                Title: jobTitle,
+                PageCount: 10,
+                RasterizationProfile: 'Black'
+            }
+        });
+        assert.strictEqual(response.statusCode, 200);
+    });
+    
+    await test('POST /createWorkflowStep', async (t) => {
+        const response = await fastify.inject({
+            method: 'POST',
+            url: '/createWorkflowStep',
+            body: {
+                Title: 'Test Step 1',
+                PreviousStep: '',
+                NextStep: '',
+                SetupTime: 5,
+                TimePerPage: 2
+            }
+        });
+        assert.strictEqual(response.statusCode, 200);
+    });
+
+    await test('POST /createWorkflow', async (t) => {
+        const response = await fastify.inject({
+            method: 'POST',
+            url: '/createWorkflow',
+            body: {
+                Title: 'Test Workflow',
+                WorkflowSteps: ['Test Step 1']
+            }
+        });
+        assert.strictEqual(response.statusCode, 200);
+    });
+
+    // Get the print job and workflow id
+    test('GET /getPrintJob', async (t) => {
+        const title = encodeURIComponent(jobTitle);
+        const response = await fastify.inject({
+            method: 'GET',
+            url: `/getPrintJob?Title=${title}`
+        });
+        assert.strictEqual(response.statusCode, 200);
+        const payload = JSON.parse(response.payload);
+        assert.ok(payload)
+
+        ctx.workflowID = payload.WorkflowID;
+        ctx.jobID = payload.PrintJobID; 
+    });
+
+    // Generate the simulation report
+    test('GET /generateSimulationReport', async (t) => {
+        response = await fastify.inject({
+            method: 'GET',
+            url: '/generateSimulationReport',
+            query: {
+                jobID: ctx.jobID,
+                workflowID: ctx.workflowID
+            }
+        });
+        if (response.statusCode !== 200) {
+            console.log("Error: ", response.payload);
+        }
+        assert.strictEqual(response.statusCode, 200);
+        let simulationReport = await JSON.parse(response.payload);
+        assert.ok(simulationReport);
+        assert.strictEqual(simulationReport.PrintJobID, ctx.jobID);
+        assert.strictEqual(simulationReport.WorkflowID, ctx.workflowID);
+        console.log("Generated simulation report: ", simulationReport);
+    });
+
+    test('GET /getSimulationReport', async (t) => {
+        // Make sure that the simulation report 
+        // can be retrieved
+        response = await fastify.inject({
+            method: 'GET',
+            url: `/getSimulationReport?jobID=${encodeURIComponent(ctx.jobID)}&workflowID=${encodeURIComponent(ctx.workflowID)}`
+        });
+        assert.strictEqual(response.statusCode, 200);
+        const payload = JSON.parse(response.payload);
+        assert.ok(payload);
+        console.log("Simulation Report: ", payload);
+    });
+})
+
+// GET API CALLS
 test('GET /', async (t) => {
     const response = await fastify.inject({
         method: 'GET',
@@ -18,49 +116,6 @@ test('GET /', async (t) => {
     });
     assert.strictEqual(response.statusCode, 200);
     assert.strictEqual(response.payload, 'Hello, client!');
-});
-
-test('POST /createJob', async (t) => {
-    const response = await fastify.inject({
-        method: 'POST',
-        url: '/createJob',
-        body: {
-            Title: 'Test Job',
-            PageCount: 10,
-            RasterizationProfile: 'Black'
-        }
-    });
-    assert.strictEqual(response.statusCode, 200);
-    assert.strictEqual(response.payload, 'Operation successful\n');
-});
-
-test('POST /createWorkflow', async (t) => {
-    const response = await fastify.inject({
-        method: 'POST',
-        url: '/createWorkflow',
-        body: {
-            Title: 'Test Workflow',
-            WorkflowSteps: ['Step1', 'Step2']
-        }
-    });
-    assert.strictEqual(response.statusCode, 200);
-    assert.strictEqual(response.payload, 'Operation successful\n');
-});
-
-test('POST /createWorkflowStep', async (t) => {
-    const response = await fastify.inject({
-        method: 'POST',
-        url: '/createWorkflowStep',
-        body: {
-            Title: 'Test Step',
-            PreviousStep: 'Step1',
-            NextStep: 'Step2',
-            SetupTime: 5,
-            TimePerPage: 2
-        }
-    });
-    assert.strictEqual(response.statusCode, 200);
-    assert.strictEqual(response.payload, 'Operation successful\n');
 });
 
 test('GET /query', async (t) => {
@@ -74,51 +129,16 @@ test('GET /query', async (t) => {
     console.log("Query Results: ", JSON.parse(response.payload));
 });
 
-test('GET /getPrintJob', async (t) => {
-    const Title = encodeURIComponent("PrintJob 1");
+test('GET /getWorkflowStepList', async (t) => {
     const response = await fastify.inject({
         method: 'GET',
-        url: `/getPrintJob?Title=${Title}`
-    });
-    const payload = JSON.parse(response.payload);
-    assert.strictEqual(response.statusCode, 200);
-    assert(Array.isArray(payload));
-    console.log("getPrintJob Results: ", JSON.parse(response.payload));
-});
-
-test('GET /getWorkflowList', async (t) => {
-    const response = await fastify.inject({
-        method: 'GET',
-        url: '/getWorkflowList'
+        url: '/getWorkflowStepList'
     });
     assert.strictEqual(response.statusCode, 200);
     const payloadList = response.payload;
-    if (!payloadList) console.error("payload is null");
-    else console.log("All workflows: ", payloadList);
-});
-
-test('GET /getSimulationReport', async (t) => {
-    // Get an existing simulation report
-    let response = await fastify.inject({
-        method: 'GET',
-        url: '/getSimulationReportList'
-    });
-    assert.strictEqual(response.statusCode, 200);
-    const payloadList = JSON.parse(response.payload);
     assert.ok(payloadList);
-    const testPrintJobId = payloadList[0].PrintJobID;
-    const testWorkflowId = payloadList[0].WorkflowID;
-
-    // Make sure that the simulation report 
-    // can be retrieved
-    response = await fastify.inject({
-        method: 'GET',
-        url: `/getSimulationReport?jobID=${encodeURIComponent(testPrintJobId)}&workflowID=${encodeURIComponent(testWorkflowId)}`
-    });
-    assert.strictEqual(response.statusCode, 200);
-    const payload = JSON.parse(response.payload);
-    assert.ok(payload);
-    console.log("Simulation Report: ", payload);
+    assert.notEqual(payloadList.length, 0);
+    console.log("All workflow steps: ", payloadList);
 });
 
 test('GET /getSimulationReportList', async (t) => {
@@ -131,49 +151,4 @@ test('GET /getSimulationReportList', async (t) => {
     assert.ok(payloadList);
     assert.notEqual(payloadList.length, 0);
     console.log("All simulation reports: ", payloadList);
-});
-
-test('GET /generateSimulationReport', async (t) => {
-    // Get an existing simulation report
-    let response = await fastify.inject({
-        method: 'GET',
-        url: '/getSimulationReportList'
-    });
-    assert.strictEqual(response.statusCode, 200);
-    const payloadList = JSON.parse(response.payload);
-    assert.ok(payloadList);
-    const testPrintJobId = payloadList[0].PrintJobID;
-    const testWorkflowId = payloadList[0].WorkflowID;
-
-    // Regenerate a new simulation report based
-    // on that print job and workflow
-    response = await fastify.inject({
-        method: 'GET',
-        url: '/generateSimulationReport',
-        query: {
-            jobID: testPrintJobId,
-            workflowID: testWorkflowId
-        }
-    });
-    if (response.statusCode !== 200) {
-        console.log("Error: ", response.payload);
-    }
-    assert.strictEqual(response.statusCode, 200);
-    let simulationReport = await JSON.parse(response.payload);
-    assert.ok(simulationReport);
-    assert.strictEqual(simulationReport.PrintJobID, testPrintJobId);
-    assert.strictEqual(simulationReport.WorkflowID, testWorkflowId);
-    console.log("Generated simulation report: ", simulationReport);
-});
-
-test('GET /getWorkflowStepList', async (t) => {
-    const response = await fastify.inject({
-        method: 'GET',
-        url: '/getWorkflowStepList'
-    });
-    assert.strictEqual(response.statusCode, 200);
-    const payloadList = response.payload;
-    assert.ok(payloadList);
-    assert.notEqual(payloadList.length, 0);
-    console.log("All workflow steps: ", payloadList);
 });

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -30,6 +30,9 @@ test('Full simulation report flow', async (ctx) => {
         });
         assert.strictEqual(response.statusCode, 200);
         assert.ok(response.payload);
+        const jobID = response.payload.toString().replace(/"/g, '');
+        //console.log("ctx.jobID: ", jobID);
+        ctx.jobID = jobID;
     });
     
     // 2. Create a new workflow step
@@ -66,9 +69,12 @@ test('Full simulation report flow', async (ctx) => {
         });
         assert.strictEqual(response.statusCode, 200);
         assert.ok(response.payload);
+        const workflowID = response.payload.toString().replace(/"/g, '');
+        //console.log("ctx.workflowID: ", workflowID);
+        ctx.workflowID = workflowID;
     });
 
-    // 4. Get the print job and workflow id
+    // 4. Get the print job by its title
     await test('GET /getPrintJob', async () => {
         const response = await fastify.inject({
             method: 'GET',
@@ -76,14 +82,10 @@ test('Full simulation report flow', async (ctx) => {
         });
         assert.strictEqual(response.statusCode, 200);
         const payload = JSON.parse(response.payload);
-        console.log("payload: ", payload);  
+        //console.log("payload: ", payload);  
         assert.ok(payload)
-
-        ctx.workflowID = payload.WorkflowID;
-        ctx.jobID = payload.PrintJobID; 
-
-        console.log("ctx.workflowID: ", ctx.workflowID);
-        console.log("ctx.jobID: ", ctx.jobID);
+        assert.strictEqual(payload.Title, ctx.jobTitle);
+        assert.strictEqual(payload._id, ctx.jobID);
     });
 
     // 5. Generate the simulation report from the print job and workflow

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -48,7 +48,6 @@ test('Full simulation report flow', async (ctx) => {
         assert.strictEqual(response.statusCode, 200);
         assert.ok(response.payload);
         const stepID = response.payload.toString();
-        console.log("HERE: ", stepID);
         ctx.stepID = stepID;
     });
 

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -46,9 +46,10 @@ test('Full simulation report flow', async (ctx) => {
             }
         });
         assert.strictEqual(response.statusCode, 200);
-        // TODO: testing this
-        console.log("HERE: ", response.payload);
-        ctx.stepID = response.payload;
+        assert.ok(response.payload);
+        const stepID = response.payload.toString();
+        console.log("HERE: ", stepID);
+        ctx.stepID = stepID;
     });
 
     // 3. Create a new workflow with the above step

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -54,10 +54,9 @@ test('Full simulation report flow', async (ctx) => {
 
     // 3. Create a new workflow with the above step
     await test('POST /createWorkflow', async () => {
-        console.log("ctx.stepID: ", ctx.stepID);    
         const data = {
             Title: "Test Workflow",
-            WorkflowSteps: [ ctx.stepID ]
+            WorkflowSteps: [ new ObjectId(ctx.stepID).toString() ]
         }
         const response = await fastify.inject({
             method: 'POST',
@@ -71,7 +70,6 @@ test('Full simulation report flow', async (ctx) => {
 
     // 4. Get the print job and workflow id
     await test('GET /getPrintJob', async () => {
-        console.log ("ctx.jobTitle: ", ctx.jobTitle);   
         const response = await fastify.inject({
             method: 'GET',
             url: `/getPrintJob?Title=${encodeURIComponent(ctx.jobTitle)}`,

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -29,10 +29,11 @@ describe('Full simulation report flow', async () => {
                 RasterizationProfile: 'Black'
             }
         });
+        console.log(response.payload);
         assert.strictEqual(response.statusCode, 200);
         assert.ok(response.payload);
         const jobID = response.payload.toString().replace(/"/g, '');
-        console.log("ctx.jobID: ", jobID);
+        //console.log("ctx.jobID: ", jobID);
         ctx.jobID = jobID;
     });
 
@@ -49,6 +50,7 @@ describe('Full simulation report flow', async () => {
                 TimePerPage: 2
             }
         });
+        console.log(response.payload);
         assert.strictEqual(response.statusCode, 200);
         assert.ok(response.payload);
         const stepID = response.payload.toString().replace(/"/g, '');
@@ -68,10 +70,11 @@ describe('Full simulation report flow', async () => {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(data)
         });
+        console.log(response.payload);
         assert.strictEqual(response.statusCode, 200);
         assert.ok(response.payload);
         const workflowID = response.payload.toString().replace(/"/g, '');
-        console.log("ctx.workflowID: ", workflowID);
+        //console.log("ctx.workflowID: ", workflowID);
         ctx.workflowID = workflowID;
     });
 
@@ -81,9 +84,9 @@ describe('Full simulation report flow', async () => {
             method: 'GET',
             url: `/getPrintJob?Title=${encodeURIComponent(ctx.jobTitle)}`,
         });
+        console.log(response.payload);
         assert.strictEqual(response.statusCode, 200);
         const payload = JSON.parse(response.payload)[0];
-        //console.log("getPrintJob payload: ", payload);
         assert.ok(payload)
         assert.equal(payload.Title, ctx.jobTitle);
         assert.equal(payload._id, ctx.jobID);
@@ -98,7 +101,6 @@ describe('Full simulation report flow', async () => {
         console.log(response.payload);
         assert.strictEqual(response.statusCode, 200);
         const simulationReport = await JSON.parse(response.payload);
-        console.log("Generated simulation report: ", simulationReport);
         assert.ok(simulationReport);
         assert.strictEqual(simulationReport.PrintJobID, ctx.jobID);
         assert.strictEqual(simulationReport.WorkflowID, ctx.workflowID);

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -127,7 +127,7 @@ describe('Full simulation report flow', async () => {
 })
 
 // GET API CALLS
-describe('GET /', async () => {
+test('GET /', async () => {
     const response = await fastify.inject({
         method: 'GET',
         url: '/'
@@ -136,7 +136,7 @@ describe('GET /', async () => {
     assert.strictEqual(response.payload, 'Hello, client!');
 });
 
-describe('GET /query', async () => {
+test('GET /query', async () => {
     const CollectionName = encodeURIComponent('PrintJob');
     const Query = encodeURIComponent(JSON.stringify({ Title: "PrintJob 1" }))
     const response = await fastify.inject({
@@ -147,7 +147,7 @@ describe('GET /query', async () => {
     console.log("Query Results: ", JSON.parse(response.payload));
 });
 
-describe('GET /getWorkflowStepList', async () => {
+test('GET /getWorkflowStepList', async () => {
     const response = await fastify.inject({
         method: 'GET',
         url: '/getWorkflowStepList'
@@ -159,7 +159,7 @@ describe('GET /getWorkflowStepList', async () => {
     console.log("All workflow steps: ", payloadList);
 });
 
-describe('GET /getSimulationReportList', async () => {
+test('GET /getSimulationReportList', async () => {
     const response = await fastify.inject({
         method: 'GET',
         url: '/getSimulationReportList'

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -54,6 +54,7 @@ test('Full simulation report flow', async (ctx) => {
 
     // 3. Create a new workflow with the above step
     await test('POST /createWorkflow', async () => {
+        console.log("ctx.stepID: ", ctx.stepID);    
         const data = {
             Title: "Test Workflow",
             WorkflowSteps: [ ctx.stepID ]

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -95,6 +95,7 @@ describe('Full simulation report flow', async () => {
             method: 'GET',
             url: "/generateSimulationReport?jobID=" + ctx.jobID + "&workflowID=" + ctx.workflowID,
         });
+        console.log(response.payload);
         assert.strictEqual(response.statusCode, 200);
         const simulationReport = await JSON.parse(response.payload);
         console.log("Generated simulation report: ", simulationReport);
@@ -112,6 +113,7 @@ describe('Full simulation report flow', async () => {
             method: 'GET',
             url: "/getSimulationReport?jobID=" + ctx.jobID + "&workflowID=" + ctx.workflowID
         });
+        console.log(response.payload);
         assert.strictEqual(response.statusCode, 200);
         const payload = JSON.parse(response.payload);
         assert.ok(payload);

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -34,7 +34,7 @@ test('Full simulation report flow', async (ctx) => {
         //console.log("ctx.jobID: ", jobID);
         ctx.jobID = jobID;
     });
-    
+
     // 2. Create a new workflow step
     await test('POST /createWorkflowStep', async () => {
         const response = await fastify.inject({
@@ -59,12 +59,12 @@ test('Full simulation report flow', async (ctx) => {
     await test('POST /createWorkflow', async () => {
         const data = {
             Title: "Test Workflow",
-            WorkflowSteps: [ ctx.stepID ]
+            WorkflowSteps: [ctx.stepID]
         }
         const response = await fastify.inject({
             method: 'POST',
             url: '/createWorkflow',
-            headers: {'Content-Type': 'application/json'},
+            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(data)
         });
         assert.strictEqual(response.statusCode, 200);
@@ -81,28 +81,33 @@ test('Full simulation report flow', async (ctx) => {
             url: `/getPrintJob?Title=${encodeURIComponent(ctx.jobTitle)}`,
         });
         assert.strictEqual(response.statusCode, 200);
-        const payload = JSON.parse(response.payload);
-        console.log("getPrintJob payload: ", payload);  
+        const payload = JSON.parse(response.payload[0]);
+        console.log("getPrintJob payload: ", payload);
         assert.ok(payload)
-        assert.strictEqual(payload.Title, ctx.jobTitle);
-        assert.strictEqual(payload._id, ctx.jobID);
+        assert.equal(payload.Title, ctx.jobTitle);
+        assert.equal(payload._id, ctx.jobID);
     });
 
     // 5. Generate the simulation report from the print job and workflow
     await test('GET /generateSimulationReport', async () => {
-        response = await fastify.inject({
+        const data =
+        {
+            jobID: ctx.jobID,
+            workflowID: ctx.workflowID
+        };
+        console.log("data: ", data);
+        const response = await fastify.inject({
             method: 'GET',
             url: '/generateSimulationReport',
-            query: {
-                jobID: ctx.jobID,
-                workflowID: ctx.workflowID
-            }
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data)
         });
         if (response.statusCode !== 200) {
             console.log("Error: ", response.payload);
         }
         assert.strictEqual(response.statusCode, 200);
-        const simulationReport = await JSON.parse(response.payload);
+        const simulationReport = await JSON.parse(response.payload[0]);
+        console.log("Simulation Report: ", simulationReport);
         assert.ok(simulationReport);
         assert.strictEqual(simulationReport.PrintJobID, ctx.jobID);
         assert.strictEqual(simulationReport.WorkflowID, ctx.workflowID);

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -60,17 +60,14 @@ test('Full simulation report flow', async (ctx) => {
 
     // Get the print job and workflow id
     await test('GET /getPrintJob', async () => {
+        console.log ("ctx.jobTitle: ", ctx.jobTitle);   
         const response = await fastify.inject({
             method: 'GET',
-            url: `/getPrintJob`,
-            query: {
-                Title: ctx.jobTitle 
-            }
+            url: `/getPrintJob?Title=${encodeURIComponent(ctx.jobTitle)}`,
         });
         assert.strictEqual(response.statusCode, 200);
         const payload = JSON.parse(response.payload);
         assert.ok(payload)
-        console.log("LOOK HERE: \n" + payload);
 
         ctx.workflowID = payload.WorkflowID;
         ctx.jobID = payload.PrintJobID; 

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -70,7 +70,7 @@ test('Full simulation report flow', async (ctx) => {
         assert.strictEqual(response.statusCode, 200);
         const payload = JSON.parse(response.payload);
         assert.ok(payload)
-        console.error(payload);
+        console.log(payload);
 
         ctx.workflowID = payload.WorkflowID;
         ctx.jobID = payload.PrintJobID; 

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -13,7 +13,7 @@ after(() => {
 
 // SEQUENCED TEST
 test('Full simulation report flow', async (ctx) => {
-    const jobTitle = "Test Job";
+    ctx.jobTitle = "Test Job";
     ctx.jobID = "";
     ctx.workflowID = "";
 
@@ -23,7 +23,7 @@ test('Full simulation report flow', async (ctx) => {
             method: 'POST',
             url: '/createJob',
             body: {
-                Title: jobTitle,
+                Title: ctx.jobTitle,
                 PageCount: 10,
                 RasterizationProfile: 'Black'
             }
@@ -60,10 +60,12 @@ test('Full simulation report flow', async (ctx) => {
 
     // Get the print job and workflow id
     await test('GET /getPrintJob', async () => {
-        const title = encodeURIComponent(jobTitle);
         const response = await fastify.inject({
             method: 'GET',
-            url: `/getPrintJob?Title=${title}`
+            url: `/getPrintJob`,
+            query: {
+                Title: ctx.jobTitle 
+            }
         });
         assert.strictEqual(response.statusCode, 200);
         const payload = JSON.parse(response.payload);

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -91,17 +91,9 @@ describe('Full simulation report flow', async () => {
 
     // 5. Generate the simulation report from the print job and workflow
     await test('GET /generateSimulationReport', async () => {
-        const data =
-        {
-            jobID: ctx.jobID,
-            workflowID: ctx.workflowID
-        };
-        //console.log("data: ", data);
         const response = await fastify.inject({
             method: 'GET',
-            url: '/generateSimulationReport',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(data)
+            url: "/generateSimulationReport?jobID=" + ctx.jobID + "&workflowID=" + ctx.workflowID,
         });
         assert.strictEqual(response.statusCode, 200);
         const simulationReport = await JSON.parse(response.payload);
@@ -118,7 +110,7 @@ describe('Full simulation report flow', async () => {
         // can be retrieved
         response = await fastify.inject({
             method: 'GET',
-            url: `/getSimulationReport?jobID=${encodeURIComponent(ctx.jobID)}&workflowID=${encodeURIComponent(ctx.workflowID)}`
+            url: "/getSimulationReport?jobID=" + ctx.jobID + "&workflowID=" + ctx.workflowID
         });
         assert.strictEqual(response.statusCode, 200);
         const payload = JSON.parse(response.payload);

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -56,7 +56,7 @@ test('Full simulation report flow', async (ctx) => {
     await test('POST /createWorkflow', async () => {
         const data = {
             Title: "Test Workflow",
-            WorkflowSteps: [ new ObjectId(ctx.stepID).toString() ]
+            WorkflowSteps: [ ctx.stepID ]
         }
         const response = await fastify.inject({
             method: 'POST',

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -144,6 +144,18 @@ test('GET /query', async () => {
     //console.log("Query Results: ", JSON.parse(response.payload));
 });
 
+test('GET /getWorkflowList', async () => {
+    const response = await fastify.inject({
+        method: 'GET',
+        url: '/getWorkflowList'
+    });
+    assert.strictEqual(response.statusCode, 200);
+    const payloadList = response.payload;
+    assert.ok(payloadList);
+    assert.notEqual(payloadList.length, 0);
+    //console.log("All workflows: ", payloadList);
+});
+
 test('GET /getWorkflowStepList', async () => {
     const response = await fastify.inject({
         method: 'GET',

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -82,7 +82,7 @@ test('Full simulation report flow', async (ctx) => {
         });
         assert.strictEqual(response.statusCode, 200);
         const payload = JSON.parse(response.payload);
-        //console.log("payload: ", payload);  
+        console.log("getPrintJob payload: ", payload);  
         assert.ok(payload)
         assert.strictEqual(payload.Title, ctx.jobTitle);
         assert.strictEqual(payload._id, ctx.jobID);

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -1,4 +1,4 @@
-const { test, before, after } = require('node:test');
+const { test, before, after, describe } = require('node:test');
 const assert = require('node:assert');
 const { fastify, start, } = require('../../server.js');
 
@@ -11,7 +11,8 @@ after(() => {
 }
 );
 
-test('Full simulation report flow', async (ctx) => {
+describe('Full simulation report flow', async () => {
+    ctx = {};
     ctx.jobTitle = "Test Job";
     ctx.jobID = "";
     ctx.stepID = "";
@@ -31,7 +32,7 @@ test('Full simulation report flow', async (ctx) => {
         assert.strictEqual(response.statusCode, 200);
         assert.ok(response.payload);
         const jobID = response.payload.toString().replace(/"/g, '');
-        //console.log("ctx.jobID: ", jobID);
+        console.log("ctx.jobID: ", jobID);
         ctx.jobID = jobID;
     });
 
@@ -70,7 +71,7 @@ test('Full simulation report flow', async (ctx) => {
         assert.strictEqual(response.statusCode, 200);
         assert.ok(response.payload);
         const workflowID = response.payload.toString().replace(/"/g, '');
-        //console.log("ctx.workflowID: ", workflowID);
+        console.log("ctx.workflowID: ", workflowID);
         ctx.workflowID = workflowID;
     });
 
@@ -82,7 +83,7 @@ test('Full simulation report flow', async (ctx) => {
         });
         assert.strictEqual(response.statusCode, 200);
         const payload = JSON.parse(response.payload)[0];
-        console.log("getPrintJob payload: ", payload);
+        //console.log("getPrintJob payload: ", payload);
         assert.ok(payload)
         assert.equal(payload.Title, ctx.jobTitle);
         assert.equal(payload._id, ctx.jobID);
@@ -95,16 +96,13 @@ test('Full simulation report flow', async (ctx) => {
             jobID: ctx.jobID,
             workflowID: ctx.workflowID
         };
-        console.log("data: ", data);
+        //console.log("data: ", data);
         const response = await fastify.inject({
             method: 'GET',
             url: '/generateSimulationReport',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(data)
         });
-        if (response.statusCode !== 200) {
-            console.log("Error: ", response.payload);
-        }
         assert.strictEqual(response.statusCode, 200);
         const simulationReport = await JSON.parse(response.payload);
         console.log("Generated simulation report: ", simulationReport);
@@ -129,7 +127,7 @@ test('Full simulation report flow', async (ctx) => {
 })
 
 // GET API CALLS
-test('GET /', async () => {
+describe('GET /', async () => {
     const response = await fastify.inject({
         method: 'GET',
         url: '/'
@@ -138,7 +136,7 @@ test('GET /', async () => {
     assert.strictEqual(response.payload, 'Hello, client!');
 });
 
-test('GET /query', async () => {
+describe('GET /query', async () => {
     const CollectionName = encodeURIComponent('PrintJob');
     const Query = encodeURIComponent(JSON.stringify({ Title: "PrintJob 1" }))
     const response = await fastify.inject({
@@ -149,7 +147,7 @@ test('GET /query', async () => {
     console.log("Query Results: ", JSON.parse(response.payload));
 });
 
-test('GET /getWorkflowStepList', async () => {
+describe('GET /getWorkflowStepList', async () => {
     const response = await fastify.inject({
         method: 'GET',
         url: '/getWorkflowStepList'
@@ -161,7 +159,7 @@ test('GET /getWorkflowStepList', async () => {
     console.log("All workflow steps: ", payloadList);
 });
 
-test('GET /getSimulationReportList', async () => {
+describe('GET /getSimulationReportList', async () => {
     const response = await fastify.inject({
         method: 'GET',
         url: '/getSimulationReportList'


### PR DESCRIPTION
* `server.test.js` now properly tests the API calls with IDs, not titles
* added a suite (`describe`) that runs through our entire code flow: `createWorkflow` and `createPrintJob` → `generateSimulationReport` → `getSimulationReport`
* made all the functions in `mongodb.js` return the inserted ID as an `ObjectID`. This caused headache for me because the string representation is `"id"` not just `id`, so I had to add a case to explicitly remove the `"`.
* added proper parameter checking to `mongodb.js` and `server.js`
* fixed a bug where `simulation.js` threw an error when a new workflow step was encountered
* also included more comments/documentation. `simulation.js` needs work too, but I didn't do it here