### PR TITLE
fix: get rid of validation temporarily

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -460,9 +460,10 @@ pub async fn insert_rasterization_profile(data: RasterizationProfile) -> Result<
 
 pub async fn insert_workflow(data: WorkflowArgs) -> Result<DocID,CustomError> {
     // Ensure that the workflow is valid
-    if !is_valid_workflow(&data) {
-        return Err(CustomError::OtherError("Invalid workflow".to_string()));
-    }
+    // TODO: uncomment once frontend can actually send valid workflows
+    // if !is_valid_workflow(&data) {
+    //     return Err(CustomError::OtherError("Invalid workflow".to_string()));
+    // }
     let db = DB_CONNECTION.lock().unwrap();
 
     // Insert the Workflow


### PR DESCRIPTION
Frontend needs to modify the "create workflows" page to be able to send valid workflows